### PR TITLE
Allow overriding `connection` while executing the sql magic.

### DIFF
--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -90,7 +90,7 @@ class SQLCommand:
             self.parsed["connection"] = self.args.line[0]
 
         if connection is not None:
-            self.parsed['connection'] = connection
+            self.parsed["connection"] = connection
 
         if self.args.with_:
             self.args.with_ = [

--- a/src/sql/command.py
+++ b/src/sql/command.py
@@ -22,7 +22,7 @@ class SQLCommand:
 
     """
 
-    def __init__(self, magic, user_ns, line, cell) -> None:
+    def __init__(self, magic, user_ns, line, cell, connection=None) -> None:
         self._line = line
         self._cell = cell
 
@@ -88,6 +88,9 @@ class SQLCommand:
 
         if add_alias:
             self.parsed["connection"] = self.args.line[0]
+
+        if connection is not None:
+            self.parsed['connection'] = connection
 
         if self.args.with_:
             self.args.with_ = [

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -335,7 +335,7 @@ class SqlMagic(Magics, Configurable):
         action="append",
         help="Interactive mode",
     )
-    def execute(self, line="", cell="", local_ns=None):
+    def execute(self, line="", cell="", local_ns=None, connection=None):
         """
         Runs SQL statement against a database, specified by
         SQLAlchemy connect string.
@@ -363,16 +363,19 @@ class SqlMagic(Magics, Configurable):
 
         """
         return self._execute(
-            line=line, cell=cell, local_ns=local_ns, is_interactive_mode=False
+            line=line, cell=cell, local_ns=local_ns, is_interactive_mode=False, connection=connection
         )
 
     @modify_exceptions
-    def _execute(self, line, cell, local_ns, is_interactive_mode=False):
+    def _execute(self, line, cell, local_ns, is_interactive_mode=False, connection=None):
         """
         This function implements the cell logic; we create this private
         method so we can control how the function is called. Otherwise,
         decorating ``SqlMagic.execute`` will break when adding the ``@log_call``
         decorator with ``payload=True``
+
+        ``connection`` is any [DBAPI v2](https://peps.python.org/pep-0249/) compatible connection object.
+        If provided, it will override any other connection configuration.
 
         NOTE: telemetry has been removed, we can remove this function
         """
@@ -401,7 +404,7 @@ class SqlMagic(Magics, Configurable):
         user_ns = self.shell.user_ns.copy()
         user_ns.update(local_ns)
 
-        command = SQLCommand(self, user_ns, line, cell)
+        command = SQLCommand(self, user_ns, line, cell, connection)
         # args.line: contains the line after the magic with all options removed
 
         args = command.args

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -363,11 +363,17 @@ class SqlMagic(Magics, Configurable):
 
         """
         return self._execute(
-            line=line, cell=cell, local_ns=local_ns, is_interactive_mode=False, connection=connection
+            line=line,
+            cell=cell,
+            local_ns=local_ns,
+            is_interactive_mode=False,
+            connection=connection,
         )
 
     @modify_exceptions
-    def _execute(self, line, cell, local_ns, is_interactive_mode=False, connection=None):
+    def _execute(
+        self, line, cell, local_ns, is_interactive_mode=False, connection=None
+    ):
         """
         This function implements the cell logic; we create this private
         method so we can control how the function is called. Otherwise,


### PR DESCRIPTION
## Describe your changes

Allow overriding `connection` while executing the sql magic. This is used in https://github.com/singlestore-labs/singlestoredb-python/pull/47.

## Issue number



## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/submitting-pr.html#changelog) (when needed)

